### PR TITLE
Remove transform: translate from buttons

### DIFF
--- a/stolen-buttons/stolen-buttons.css
+++ b/stolen-buttons/stolen-buttons.css
@@ -40,6 +40,10 @@ body {
     }
 }
 
+.stolen-button *[style*="transform: translate"] {
+    transform: none !important
+}
+
 #stolen-buttons a,
 #stolen-buttons button {
     margin-inline: 0 !important;


### PR DESCRIPTION
Theo just uploaded a video featuring your extension
https://www.youtube.com/watch?v=r_A6oMULtGM

He noticed that `transform: translate[x/y]` misplaces buttons, so I'm making a small change that fixes it.